### PR TITLE
Link RevolutionConf to the active Hampton Roads DevFest

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -35,6 +35,15 @@ const structuredData = {
         "https://www.facebook.com/revconf/",
         "https://github.com/revolutionva",
       ],
+      // The org's currently-active conference. Declaring it here is what lets a
+      // crawler or model connect this dormant site to the live one, rather than
+      // treating the two domains as unrelated islands.
+      event: {
+        "@type": "EventSeries",
+        name: "Hampton Roads DevFest",
+        url: "https://hrdevfest.org",
+        organizer: { "@id": "https://revolutionva.org/#organization" },
+      },
     },
     {
       "@type": "WebSite",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -90,7 +90,12 @@ const structuredData = {
           >, a 501(c)(3) nonprofit based in Norfolk, VA.
         </p>
         <p class="text-xl pt-5">
-          There is currently no plan to hold another RevolutionConf.
+          There is currently no plan to hold another RevolutionConf. If you are
+          after something in the same spirit, RevolutionVA still runs <a
+            class="font-bold underline underline-offset-4 hover:decoration-2"
+            href="https://hrdevfest.org">Hampton Roads DevFest</a
+          >, a community-driven software development conference in Virginia
+          Beach — it returns in 2027.
         </p>
         <p class="text-xl pt-5">
           However, this can change! Send us a message at <a


### PR DESCRIPTION
## Summary

Adds the one cross-property link that carries real value, plus the structured-data relation behind it.

I mapped the actual link graph across the four RevolutionVA properties first. The hub-and-spoke is already healthy — what's missing is entirely sibling-to-sibling:

| from ↓ / to → | 757tech | hrdevfest | revolutionva | revolutionconf |
| :--- | :--- | :--- | :--- | :--- |
| **757tech** | — | ✗ | ✓ | ✗ |
| **hrdevfest** | ✗ | — | ✓ | ✗ |
| **revolutionva** | ✓ | ✓ | — | ✓ |
| **revolutionconf** | ✗ | ✗ | ✓ | — |

## Changes

**Visible copy.** The page dead-ended on *"There is currently no plan to hold another RevolutionConf."* People searching for RevolutionConf are precisely DevFest's audience, so that sentence now continues into the live event:

> There is currently no plan to hold another RevolutionConf. If you are after something in the same spirit, RevolutionVA still runs **Hampton Roads DevFest**, a community-driven software development conference in Virginia Beach — it returns in 2027.

The 2027 framing matches hrdevfest.org's own copy ("Hampton Roads DevFest returns in 2027 in Virginia Beach, VA. Dates coming soon").

**Structured data.** The `Organization` node now declares `event` → Hampton Roads DevFest, so a crawler or model can connect this dormant site to the active one rather than treating the domains as unrelated islands.

One correction to how I originally described this: I said "parentOrganization", but that property doesn't apply here — RevolutionConf is an `EventSeries`, not an `Organization`. `Organization.event` is the schema-correct relation, and the reverse direction was already covered by `EventSeries.organizer`.

## Deliberately not included

- **A four-way footer link block.** That's 12 links where 3 carry value, adds nothing for users, and a uniform mesh is the specific pattern that reads as manipulative. (To be clear, there's no realistic penalty risk either way — four related nonprofit properties with natural anchors is ordinary architecture.)
- **hrdevfest → revolutionconf.** Sending live-event visitors to a dormant conference is a dead end unless framed as history.

## Test plan

- [x] `npm run build` passes
- [x] JSON-LD parses; no dangling `@id` references
- [x] `Organization.event` resolves to `hrdevfest.org`
- [x] Outbound anchors verified: `revolutionva.org`, `hrdevfest.org`, `mailto:`, `twitter.com/revconf`
- [ ] Visual check on the preview environment

## Follow-ups in other repos

1. **757tech.org → hrdevfest.org.** 757tech bills itself as "the front door to tech in Hampton Roads," runs an events calendar with featured conferences, lists BSides — and doesn't mention its own parent org's flagship conference. Straight miss, independent of SEO.
2. **hrdevfest.org → 757tech.org.** Lower priority "more local tech events" pointer.
3. **Inconsistent social handles.** revolutionva.org cites `twitter.com/revolutionconf` and `facebook.com/revolutionconf`; this site cites `/revconf`. I could not determine which is canonical — both platforms return 200 for any path since they serve an app shell — but conflicting `sameAs` values across your own properties weaken entity resolution. Worth picking one.
4. **Shared `@id` across all four sites.** The real entity-graph win is every property asserting the same `Organization` `@id` (`https://revolutionva.org/#organization`, which this repo already uses), with `subOrganization`/`event` relations on revolutionva.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
